### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Kolab/Storage/Driver/Mock/Data.php
+++ b/lib/Horde/Kolab/Storage/Driver/Mock/Data.php
@@ -126,7 +126,7 @@ implements ArrayAccess
      *
      * @return mixed The data value.
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset) : mixed
     {
         return $this->_data[$offset];
     }
@@ -139,7 +139,7 @@ implements ArrayAccess
      *
      * @return NULL
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value) : void
     {
         $this->_data[$offset] = $value;
     }
@@ -151,7 +151,7 @@ implements ArrayAccess
      *
      * @return boolean True if the offset exists.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return isset($this->_data[$offset]);
     }
@@ -163,7 +163,7 @@ implements ArrayAccess
      *
      * @return NULL
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
         unset($this->_data[$offset]);
     }

--- a/lib/Horde/Kolab/Storage/Driver/Mock/Data.php
+++ b/lib/Horde/Kolab/Storage/Driver/Mock/Data.php
@@ -126,6 +126,7 @@ implements ArrayAccess
      *
      * @return mixed The data value.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset) : mixed
     {
         return $this->_data[$offset];
@@ -135,10 +136,11 @@ implements ArrayAccess
      * Sets the value of the given offset in this array.
      *
      * @param string|int $offset The array offset.
-     * @param mi $offset The array offset.
+     * @param mixed $offset The array offset.
      *
-     * @return NULL
+     * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value) : void
     {
         $this->_data[$offset] = $value;
@@ -149,7 +151,7 @@ implements ArrayAccess
      *
      * @param string|int $offset The array offset.
      *
-     * @return boolean True if the offset exists.
+     * @return bool True if the offset exists.
      */
     public function offsetExists($offset) : bool
     {
@@ -161,7 +163,6 @@ implements ArrayAccess
      *
      * @param string|int $offset The array offset.
      *
-     * @return NULL
      */
     public function offsetUnset($offset) : void
     {
@@ -173,6 +174,7 @@ implements ArrayAccess
      *
      * @return array The keys of this array.
      */
+    #[ReturnTypeWillChange]
     public function arrayKeys()
     {
         return array_keys($this->_data);

--- a/lib/Horde/Kolab/Storage/Folder/Namespace.php
+++ b/lib/Horde/Kolab/Storage/Folder/Namespace.php
@@ -264,7 +264,7 @@ implements IteratorAggregate, Serializable
 
     /**
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_namespaces);
     }

--- a/lib/Horde/Kolab/Storage/Folder/Namespace/Config.php
+++ b/lib/Horde/Kolab/Storage/Folder/Namespace/Config.php
@@ -80,6 +80,10 @@ extends  Horde_Kolab_Storage_Folder_Namespace
     {
         return serialize(array($this->user, $this->configuration));
     }
+    public function __serialize(): array
+    {
+        return [$this->user, $this->configuration];
+    }
 
     /**
      * Reconstruct the object from serialized data.
@@ -89,6 +93,11 @@ extends  Horde_Kolab_Storage_Folder_Namespace
     public function unserialize($data)
     {
         list($this->user, $this->configuration) = @unserialize($data);
+        $this->initialize($this->_initializeData());
+    }
+    public function __unserialize(array $data): void
+    {
+        list($this->user, $this->configuration) = $data;
         $this->initialize($this->_initializeData());
     }
 }

--- a/lib/Horde/Kolab/Storage/Folder/Namespace/Fixed.php
+++ b/lib/Horde/Kolab/Storage/Folder/Namespace/Fixed.php
@@ -60,6 +60,10 @@ extends  Horde_Kolab_Storage_Folder_Namespace
     {
         return serialize($this->user);
     }
+    public function __serialize(): array
+    {
+        return [$this->user];
+    }
 
     /**
      * Reconstruct the object from serialized data.
@@ -69,6 +73,11 @@ extends  Horde_Kolab_Storage_Folder_Namespace
     public function unserialize($data)
     {
         $this->user = @unserialize($data);
+        $this->initialize($this->_initializeData());
+    }
+    public function __unserialize(array $data): void
+    {
+        $this->user = array_pop($data);
         $this->initialize($this->_initializeData());
     }
 }

--- a/lib/Horde/Kolab/Storage/Folder/Stamp/Uids.php
+++ b/lib/Horde/Kolab/Storage/Folder/Stamp/Uids.php
@@ -158,6 +158,10 @@ implements Horde_Kolab_Storage_Folder_Stamp
     {
         return serialize(array($this->_status, $this->_ids));
     }
+    public function __serialize(): array
+    {
+        return [$this->_status, $this->_ids];
+    }
 
     /**
      * Reconstruct the object from serialized data.
@@ -167,6 +171,10 @@ implements Horde_Kolab_Storage_Folder_Stamp
     public function unserialize($data)
     {
         list($this->_status, $this->_ids) = @unserialize($data);
+    }
+    public function __unserialize(array $data): void
+    {
+        list($this->_status, $this->_ids) = $data;
     }
 
     /**

--- a/lib/Horde/Kolab/Storage/Object.php
+++ b/lib/Horde/Kolab/Storage/Object.php
@@ -578,22 +578,25 @@ class Horde_Kolab_Storage_Object implements ArrayAccess, Serializable
     }
 
     /* ArrayAccess methods. */
-
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return isset($this->_data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         return isset($this->_data[$offset]) ? $this->_data[$offset] : '';
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         $this->_data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         unset($this->_data[$offset]);
@@ -609,15 +612,20 @@ class Horde_Kolab_Storage_Object implements ArrayAccess, Serializable
     public function serialize()
     {
         return serialize(
-            array(
-                self::SERIALIZATION_DATA => $this->_data,
-                self::SERIALIZATION_ERRORS => $this->_errors,
-                self::SERIALIZATION_TYPE => $this->_type,
-                self::SERIALIZATION_FOLDER => $this->_folder,
-                self::SERIALIZATION_BACKENDID => $this->_backend_id,
-                self::SERIALIZATION_MIMEPARTID => $this->_mime_part_id,
-            )
+            $this->__serialize()
         );
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            self::SERIALIZATION_DATA => $this->_data,
+            self::SERIALIZATION_ERRORS => $this->_errors,
+            self::SERIALIZATION_TYPE => $this->_type,
+            self::SERIALIZATION_FOLDER => $this->_folder,
+            self::SERIALIZATION_BACKENDID => $this->_backend_id,
+            self::SERIALIZATION_MIMEPARTID => $this->_mime_part_id,
+        ];
     }
 
     /**
@@ -633,6 +641,27 @@ class Horde_Kolab_Storage_Object implements ArrayAccess, Serializable
         if (!is_array($data)) {
             throw new Horde_Kolab_Storage_Object_Exception('Cache data invalid');
         }
+        if (isset($data[self::SERIALIZATION_DATA])) {
+            $this->_data = $data[self::SERIALIZATION_DATA];
+        }
+        if (isset($data[self::SERIALIZATION_ERRORS])) {
+            $this->_errors = $data[self::SERIALIZATION_ERRORS];
+        }
+        if (isset($data[self::SERIALIZATION_TYPE])) {
+            $this->_type = $data[self::SERIALIZATION_TYPE];
+        }
+        if (isset($data[self::SERIALIZATION_FOLDER])) {
+            $this->_folder = $data[self::SERIALIZATION_FOLDER];
+        }
+        if (isset($data[self::SERIALIZATION_BACKENDID])) {
+            $this->_backend_id = $data[self::SERIALIZATION_BACKENDID];
+        }
+        if (isset($data[self::SERIALIZATION_MIMEPARTID])) {
+            $this->_mime_part_id = $data[self::SERIALIZATION_MIMEPARTID];
+        }
+    }
+    public function __unserialize(array $data): void
+    {
         if (isset($data[self::SERIALIZATION_DATA])) {
             $this->_data = $data[self::SERIALIZATION_DATA];
         }

--- a/lib/Horde/Kolab/Storage/Object.php
+++ b/lib/Horde/Kolab/Storage/Object.php
@@ -579,22 +579,22 @@ class Horde_Kolab_Storage_Object implements ArrayAccess, Serializable
 
     /* ArrayAccess methods. */
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->_data[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->_data[$offset]) ? $this->_data[$offset] : '';
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->_data[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->_data[$offset]);
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Kolab/Storage/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Kolab/Storage/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde KolabStorage Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Kolab/Storage/AttachmentTest.php
+++ b/test/Horde/Kolab/Storage/AttachmentTest.php
@@ -25,14 +25,14 @@
  * @author     Gunnar Wrobel <wrobel@pardus.de>
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Storage_AttachmentTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Storage_AttachmentTest extends Horde_Test_Case
 {
     /**
      * Test setup.
      *
      * @return NULL
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Broken test, prepareBasicSetup() doesn\'t exist');
 
@@ -48,7 +48,7 @@ class Horde_Kolab_Storage_AttachmentTest extends PHPUnit_Framework_TestCase
     /**
      * Test destruction.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->storage) {
             $this->storage->clean();

--- a/test/Horde/Kolab/Storage/ComponentTest/Data/Object/Message/ModifiedTest.php
+++ b/test/Horde/Kolab/Storage/ComponentTest/Data/Object/Message/ModifiedTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_ComponentTest_Data_Object_Message_ModifiedTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testStore()
     {
@@ -38,7 +38,7 @@ extends PHPUnit_Framework_TestCase
         );
         $object = new Horde_Kolab_Storage_Object();
         $object->setDriver($driver);
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));

--- a/test/Horde/Kolab/Storage/ComponentTest/Data/Object/Message/NewTest.php
+++ b/test/Horde/Kolab/Storage/ComponentTest/Data/Object/Message/NewTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_ComponentTest_Data_Object_Message_NewTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testStore()
     {
@@ -36,7 +36,7 @@ extends PHPUnit_Framework_TestCase
             $factory
         );
 
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));

--- a/test/Horde/Kolab/Storage/ComponentTest/List/CacheTest.php
+++ b/test/Horde/Kolab/Storage/ComponentTest/List/CacheTest.php
@@ -36,11 +36,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingListId()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $cache = new Horde_Kolab_Storage_List_Cache($this->getMockCache());
         $cache->getListId();
     }
@@ -77,11 +76,10 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals('DUMMY', $cache->getNamespace());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingNamespace()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $cache = $this->_getTestCache();
         $cache->getNamespace();
     }
@@ -99,11 +97,10 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals('dummy', $cache->getLongTerm('DUMMY'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingLongterm()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $cache = $this->_getTestCache();
         $cache->getLongTerm('DUMMY');
     }
@@ -205,27 +202,24 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingHost()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getTestCache(null, array('port' => 1, 'user' => 'x'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingPort()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getTestCache(null, array('host' => 'a', 'user' => 'x'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingUser()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getTestCache(null, array('host' => 'a', 'port' => 1));
     }
 

--- a/test/Horde/Kolab/Storage/ComponentTest/List/Query/List/BaseTest.php
+++ b/test/Horde/Kolab/Storage/ComponentTest/List/Query/List/BaseTest.php
@@ -30,7 +30,7 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testByTypeReturnsArray()
     {
-        $this->assertInternalType('array', $this->getNullQuery()->listByType('test'));
+        $this->assertIsArray($this->getNullQuery()->listByType('test'));
     }
 
     public function testListCalendarsListsCalendars()
@@ -51,7 +51,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testTypeReturnsArray()
     {
-        $this->assertInternalType('array', $this->getNullQuery()->listTypes());
+        $this->assertIsArray($this->getNullQuery()->listTypes());
     }
 
     public function testTypeReturnsAnnotations()
@@ -69,8 +69,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testListOwnersReturn()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertisArray(
             $this->getAnnotatedQuery()->listOwners()
         );
     }
@@ -113,8 +112,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDefaultReturn()
     {
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $this->getNamespaceQuery()->getDefault('event')
         );
     }
@@ -157,18 +155,16 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testBailOnDoubleDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getDoubleEventQuery()->getDefault('event');
     }
 
     public function testForeignDefaultReturn()
     {
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $this->getEventQuery()->getForeignDefault(
                 'someone@example.com', 'event'
             )
@@ -214,11 +210,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testBailOnDoubleForeignDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $this->getDoubleEventQuery()->getForeignDefault(
             'someone@example.com', 'event'
         );
@@ -254,7 +249,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDataByTypeReturnsArray()
     {
-        $this->assertInternalType('array', $this->getNullQuery()->dataByType('test'));
+        $this->assertIsArray($this->getNullQuery()->dataByType('test'));
     }
 
     public function testListCalendarsListsCalendarData()
@@ -291,17 +286,16 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testMissingFolderData()
     {
-        $this->assertInternalType('array', $this->getNullQuery()->folderData('INBOX/Calendar'));
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
+        $this->assertIsArray($this->getNullQuery()->folderData('INBOX/Calendar'));
     }
 
     public function testFolderDataReturnsArray()
     {
-        $this->assertInternalType('array', $this->getAnnotatedQuery()->folderData('INBOX/Calendar'));
+        $this->assertIsArray($this->getAnnotatedQuery()->folderData('INBOX/Calendar'));
     }
 
     public function testFolderDataHasOwner()

--- a/test/Horde/Kolab/Storage/ComponentTest/List/Query/List/CacheTest.php
+++ b/test/Horde/Kolab/Storage/ComponentTest/List/Query/List/CacheTest.php
@@ -32,7 +32,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getNullMock($factory), $factory);
-        $this->assertInternalType('array', $query->listTypes());
+        $this->assertIsArray($query->listTypes());
     }
 
     public function testTypeReturnsAnnotations()
@@ -56,7 +56,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getNullMock($factory), $factory);
-        $this->assertInternalType('array', $query->listByType('test'));
+        $this->assertIsArray($query->listByType('test'));
     }
 
     public function testListCalendarsListsCalendars()
@@ -77,8 +77,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getAnnotatedMock($factory), $factory);
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $query->listOwners()
         );
     }
@@ -127,8 +126,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getAnnotatedMock($factory), $factory);
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $query->getDefault('event')
         );
     }
@@ -181,11 +179,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testBailOnDoubleDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getDoubleEventMock($factory), $factory);
         $query->getDefault('event');
@@ -195,8 +192,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getEventMock($factory), $factory);
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $query->getForeignDefault('someone@example.com', 'event')
         );
     }
@@ -240,11 +236,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testBailOnDoubleForeignDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getDoubleEventMock($factory), $factory);
         $query->getForeignDefault('someone@example.com', 'event');
@@ -286,7 +281,7 @@ extends Horde_Kolab_Storage_TestCase
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $query = $this->getCachedQueryForList($this->getNullMock($factory), $factory);
-        $this->assertInternalType('array', $query->dataByType('test'));
+        $this->assertIsArray($query->dataByType('test'));
     }
 
     public function testListCalendarsListsCalendarData()
@@ -325,19 +320,18 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testMissingFolderData()
     {
-        $this->assertInternalType('array', $this->getNullQuery()->folderData('INBOX/Calendar'));
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
+        $this->assertIsArray($this->getNullQuery()->folderData('INBOX/Calendar'));
     }
 
     public function testFolderDataReturnsArray()
     {
         $factory = new Horde_Kolab_Storage_Factory();
         $data = $this->getCachedQueryForList($this->getAnnotatedMock($factory), $factory)->folderData('INBOX/Calendar');
-        $this->assertInternalType('array', $data);
+        $this->assertIsArray($data);
     }
 
     public function testFolderDataHasOwner()

--- a/test/Horde/Kolab/Storage/Server/DriverTest.php
+++ b/test/Horde/Kolab/Storage/Server/DriverTest.php
@@ -25,14 +25,14 @@
  * @author     Gunnar Wrobel <wrobel@pardus.de>
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Kolab_Storage_Server_DriverTest extends PHPUnit_Framework_TestCase
+class Horde_Kolab_Storage_Server_DriverTest extends Horde_Test_Case
 {
     const MOCK         = 'Mock';
     const CCLIENT      = 'Cclient';
     const PEAR         = 'Pear';
     const IMAP_SOCKET  = 'Imap_Socket';
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!isset($this->sharedFixture)) {
             $this->markTestSkipped('Testing of a running server skipped. No configuration fixture available.');
@@ -47,7 +47,7 @@ class Horde_Kolab_Storage_Server_DriverTest extends PHPUnit_Framework_TestCase
 
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         /** Reactivate strict reporting as we need to turn it off for PEAR-Net_IMAP */
         if (!empty($this->old_error_reporting)) {

--- a/test/Horde/Kolab/Storage/TestCase.php
+++ b/test/Horde/Kolab/Storage/TestCase.php
@@ -26,14 +26,14 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_TestCase
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = array();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_SESSION = array();
     }
@@ -59,8 +59,8 @@ extends PHPUnit_Framework_TestCase
             $driver,
             new Horde_Kolab_Storage_QuerySet_Uncached($factory),
             $factory,
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             $params
         );
     }
@@ -80,7 +80,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Kolab_Storage_QuerySet_Cached($factory, array(), $cache),
             $factory,
             $cache,
-            $this->getMock('Horde_Log_Logger')
+            $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
     }
 
@@ -535,7 +535,7 @@ extends PHPUnit_Framework_TestCase
                 array(
                     'driver' => 'mock',
                     'params' => $data,
-                    'logger' => $this->getMock('Horde_Log_Logger'),
+                    'logger' => $this->getMockBuilder('Horde_Log_Logger')->getMock(),
                     'history_prefix_generator' =>  new Horde_Kolab_Storage_Stub_HistoryPrefix()
                 ),
                 $params
@@ -568,7 +568,7 @@ extends PHPUnit_Framework_TestCase
     protected function getMockDriverList($factory = null)
     {
         $factory = $this->completeFactory($factory);
-        $this->mockDriver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->mockDriver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         return new Horde_Kolab_Storage_List_Base(
             $this->mockDriver,
             new Horde_Kolab_Storage_Factory()

--- a/test/Horde/Kolab/Storage/Unit/Cache/DataTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Cache/DataTest.php
@@ -33,11 +33,10 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals('test', $this->getMockDataCache()->getDataId());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingDataId()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $cache = new Horde_Kolab_Storage_Cache_Data($this->getMockCache());
         $cache->getDataId();
     }
@@ -69,6 +68,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjects()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getSyncedCache()->getObjects();
     }
 
@@ -80,11 +81,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingObjects()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getObjects();
     }
 
@@ -106,6 +106,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjectToBackend()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getSyncedCache()->getObjectToBackend();
     }
 
@@ -117,11 +119,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingObjectToBackend()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getObjectToBackend();
     }
 
@@ -143,6 +144,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetBackendToObject()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getSyncedCache()->getBackendToObject();
     }
 
@@ -154,11 +157,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingBackendToObject()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getBackendToObject();
     }
 
@@ -180,22 +182,22 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetStamp()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getSyncedCache()->getStamp();
     }
 
     public function testGetStampEmpty()
     {
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $this->_getSyncedCache()->getStamp()
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingStamp()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getStamp();
     }
 
@@ -217,22 +219,22 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetVersion()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getSyncedCache()->getVersion();
     }
 
     public function testGetVersionEmpty()
     {
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $this->_getSyncedCache()->getVersion()
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingVersion()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getVersion();
     }
 
@@ -276,11 +278,10 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals(array(3), $cache->getErrors());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testReset()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $cache = $this->_getSyncedCache();
         $cache->reset();
         $cache->getStamp();
@@ -478,11 +479,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingAttachmentByName()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getSyncedCacheWithAttachment('Y')
             ->getAttachmentByName('100', 'dubidu.txt');
     }
@@ -498,29 +498,26 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingAttachmentType()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getSyncedCacheWithAttachment('Y')
             ->getAttachmentByType('100', 'application/x-vnd.kolab.contact');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingAttachmentByType()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getSyncedCacheWithAttachment('Y')
             ->getAttachmentByType('200', 'application/x-vnd.kolab.event');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingQuery()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getQuery('x');
     }
 

--- a/test/Horde/Kolab/Storage/Unit/Cache/DataTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Cache/DataTest.php
@@ -204,7 +204,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testGetStampOne()
     {
         $this->assertEquals(
-            'C:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":30:{a:2:{i:0;s:1:"a";i:1;s:1:"b";}}',
+            'O:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":2:{i:0;s:1:"a";i:1;s:1:"b";}',
             $this->_getSyncedCacheWithData()->getStamp()
         );
     }
@@ -212,7 +212,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testGetStampTwo()
     {
         $this->assertEquals(
-            'C:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":30:{a:2:{i:0;s:1:"c";i:1;s:1:"d";}}',
+            'O:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":2:{i:0;s:1:"c";i:1;s:1:"d";}',
             $this->_getSyncedCacheWithMoreData()->getStamp()
         );
     }

--- a/test/Horde/Kolab/Storage/Unit/CacheTest.php
+++ b/test/Horde/Kolab/Storage/Unit/CacheTest.php
@@ -26,7 +26,7 @@
 class Horde_Kolab_Storage_Unit_CacheTest
 extends Horde_Kolab_Storage_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->horde_cache = new Horde_Cache(
@@ -61,11 +61,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDataMissingHost()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $params = $this->_getDataParameters();
         unset($params['host']);
         $this->cache->getDataCache($params);
@@ -81,11 +80,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDataMissingPort()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $params = $this->_getDataParameters();
         unset($params['port']);
         $this->cache->getDataCache($params);
@@ -101,11 +99,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDataMissingFolder()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $params = $this->_getDataParameters();
         unset($params['folder']);
         $this->cache->getDataCache($params);
@@ -121,11 +118,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDataMissingType()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $params = $this->_getDataParameters();
         unset($params['type']);
         $this->cache->getDataCache($params);
@@ -155,11 +151,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDataMissingOwner()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $params = $this->_getDataParameters();
         unset($params['owner']);
         $this->cache->getDataCache($params);

--- a/test/Horde/Kolab/Storage/Unit/CachedTest.php
+++ b/test/Horde/Kolab/Storage/Unit/CachedTest.php
@@ -30,6 +30,8 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->createCachedStorage();
     }
 

--- a/test/Horde/Kolab/Storage/Unit/Data/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Data/BaseTest.php
@@ -92,7 +92,7 @@ extends Horde_Kolab_Storage_TestCase
             ->getData('INBOX/Calendar')
             ->fetchPart(1, '2')
         );
-        $this->assertContains('<event', $part);
+        $this->assertStringContainsString('<event', $part);
     }
 
     public function testFetch()
@@ -157,8 +157,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjects()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $this->getMessageStorage()
             ->getData('INBOX/Calendar')
             ->getObjects()
@@ -178,8 +177,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjectIds()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $this->getMessageStorage()->getData('INBOX/Calendar')->getObjectIds()
         );
     }
@@ -206,11 +204,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingBackendId()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMessageStorage()
             ->getData('INBOX/Calendar')
             ->getBackendId('NOSUCHOBJECT');
@@ -245,11 +242,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingObject()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $object = $this->getMessageStorage()
             ->getData('INBOX/Calendar')
             ->getObject('NOSUCHOBJECT');
@@ -273,7 +269,7 @@ extends Horde_Kolab_Storage_TestCase
             ->fetch(array(1, 2, 4), true);
         $part = $objects[4]->getContent();
         rewind($part);
-        $this->assertContains('<uid>libkcal-543769073.130</uid>', stream_get_contents($part));
+        $this->assertStringContainsString('<uid>libkcal-543769073.130</uid>', stream_get_contents($part));
     }
 
     public function testCreateRaw()
@@ -346,11 +342,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testModifyWithoutUid()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $store = $this->getMessageStorage();
         $data = $store->getData('INBOX/Notes');
         $object = array('summary' => 'test', 'uid' => 'UID');
@@ -358,11 +353,10 @@ extends Horde_Kolab_Storage_TestCase
         $data->modify(array('summary' => 'test'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testModifyWithIncorrectUid()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $store = $this->getMessageStorage();
         $data = $store->getData('INBOX/Notes');
         $object = array('summary' => 'test', 'uid' => 'UID');

--- a/test/Horde/Kolab/Storage/Unit/Data/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Data/BaseTest.php
@@ -76,7 +76,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testStamp()
     {
         $this->assertEquals(
-            'C:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":86:{a:2:{i:0;a:2:{s:11:"uidvalidity";s:8:"12346789";s:7:"uidnext";i:5;}i:1;a:1:{i:0;i:4;}}}',
+            'O:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":2:{i:0;a:2:{s:11:"uidvalidity";s:8:"12346789";s:7:"uidnext";i:5;}i:1;a:1:{i:0;i:4;}}',
             serialize(
                 $this->getMessageStorage()
                 ->getData('INBOX/WithDeleted')

--- a/test/Horde/Kolab/Storage/Unit/Data/CachedTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Data/CachedTest.php
@@ -51,19 +51,20 @@ extends Horde_Kolab_Storage_TestCase
             $this->_getDataCache()
             ->fetchPart(1, '2')
         );
-        $this->assertContains('<event', $part);
+        $this->assertStringContainsString('<event', $part);
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingObjects()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getMockDataCache()->getObjects();
     }
 
     public function testSynchronize()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getDataCache()->synchronize();
     }
 
@@ -82,8 +83,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjects()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $this->_getDataCache()
             ->getObjects()
         );
@@ -101,8 +101,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetObjectIds()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $this->_getDataCache()->getObjectIds()
         );
     }
@@ -128,11 +127,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingBackendId()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getDataCache()
             ->getBackendId('NOSUCHOBJECT');
     }
@@ -163,11 +161,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMissingObject()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $object = $this->_getDataCache()
             ->getObject('NOSUCHOBJECT');
     }

--- a/test/Horde/Kolab/Storage/Unit/Data/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Data/Decorator/LogTest.php
@@ -31,7 +31,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testDelete()
     {
         $list = new Horde_Kolab_Storage_Data_Decorator_Log(
-            $this->getMock('Horde_Kolab_Storage_Data'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Data')->getMock(),
             $this->getMockLogger()
         );
         $list->delete('x');

--- a/test/Horde/Kolab/Storage/Unit/Driver/CclientTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/CclientTest.php
@@ -26,9 +26,9 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Driver_CclientTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         if (!function_exists('imap_open')) {

--- a/test/Horde/Kolab/Storage/Unit/Driver/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/Decorator/LogTest.php
@@ -92,8 +92,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testCreateFolderLog()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(
@@ -108,8 +108,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteFolderLog()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(
@@ -124,8 +124,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testRenameFolderLog()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(
@@ -140,40 +140,40 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testCreateFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('create')
             ->with('INBOX/Test');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $log = new Horde_Kolab_Storage_Driver_Decorator_Log($driver, $logger);
         $log->create('INBOX/Test');
     }
 
     public function testDeleteFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('delete')
             ->with('INBOX/Test');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $log = new Horde_Kolab_Storage_Driver_Decorator_Log($driver, $logger);
         $log->delete('INBOX/Test');
     }
 
     public function testRenameFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('rename')
             ->with('INBOX/Test', 'FOO');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $log = new Horde_Kolab_Storage_Driver_Decorator_Log($driver, $logger);
         $log->rename('INBOX/Test', 'FOO');
     }
 
     public function testSetAclLogsEntry()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('setAcl')
             ->with('a', 'b', 'c');
@@ -187,7 +187,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteAclLogsEntry()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('deleteAcl')
             ->with('a', 'b');

--- a/test/Horde/Kolab/Storage/Unit/Driver/Decorator/TimerTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/Decorator/TimerTest.php
@@ -28,7 +28,7 @@
 class Horde_Kolab_Storage_Unit_Driver_Decorator_TimerTest
 extends Horde_Kolab_Storage_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         if (!class_exists('Horde_Support_Timer')) {
@@ -106,7 +106,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testCreateLogsEntry()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('create')
             ->with('a');
@@ -121,7 +121,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testSetAclLogsEntry()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('setAcl')
             ->with('a', 'b', 'c');
@@ -136,7 +136,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteAclLogsEntry()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('deleteAcl')
             ->with('a', 'b');

--- a/test/Horde/Kolab/Storage/Unit/Driver/ImapTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/ImapTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Driver_ImapTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testGetNamespaceReturnsNamespaceHandler()
     {
@@ -74,7 +74,7 @@ extends PHPUnit_Framework_TestCase
 
     private function _getNamespaceMock()
     {
-        $imap = $this->getMock('Horde_Imap_Client_Socket', array(), array(), '', false, false);
+        $imap = $this->getMockBuilder('Horde_Imap_Client_Socket')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $imap->expects($this->once())
             ->method('queryCapability')
             ->with('NAMESPACE')

--- a/test/Horde/Kolab/Storage/Unit/Driver/MockTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/MockTest.php
@@ -30,7 +30,7 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testGetMailboxesReturnsArray()
     {
-        $this->assertInternalType('array', $this->getNullMock()->listFolders());
+        $this->assertIsArray($this->getNullMock()->listFolders());
     }
 
     public function testGetMailboxesEmpty()
@@ -56,19 +56,17 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetAclFailsOnMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getNullMock()->getAcl('INBOX/test');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetAclOnHidden()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', $mock->getAuth(), '');
@@ -115,19 +113,17 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals(array('group:group' => 'a'), $mock->getAcl('INBOX/Test'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMyAclFailsOnMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getNullMock()->getMyAcl('INBOX/test');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testGetMyAclOnHidden()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->deleteAcl('INBOX/Test', $mock->getAuth());
@@ -162,19 +158,17 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals('l', $mock->getMyAcl('INBOX/Test'));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testSetAclFailsOnMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getNullMock()->setAcl('INBOX/test', 'a', 'b');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testSetAclOnHidden()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->deleteAcl('INBOX/Test', $mock->getAuth());
@@ -195,6 +189,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testSetAclWithAnyone()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', 'anyone', 'a');
@@ -204,6 +200,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testSetAclWithAnonymous()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', 'anonymous', 'a');
@@ -213,6 +211,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testSetAclWithGroup()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->setGroups(array($mock->getAuth() => array('group')));
         $mock->create('INBOX/Test');
@@ -221,19 +221,17 @@ extends Horde_Kolab_Storage_TestCase
         $mock->setAcl('INBOX/Test', 'a', 'b');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDeleteAclFailsOnMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getNullMock()->deleteAcl('INBOX/test', 'a');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDeleteAclOnHidden()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', $mock->getAuth(), '');
@@ -254,6 +252,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteAclWithAnyone()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', 'anyone', 'a');
@@ -263,6 +263,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteAclWithAnonymous()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->create('INBOX/Test');
         $mock->setAcl('INBOX/Test', 'anonymous', 'a');
@@ -272,6 +274,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testDeleteAclWithGroup()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getNullMock();
         $mock->setGroups(array($mock->getAuth() => array('group')));
         $mock->create('INBOX/Test');
@@ -280,18 +284,16 @@ extends Horde_Kolab_Storage_TestCase
         $mock->deleteAcl('INBOX/Test', 'group:group');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testSetAnnotationFailsOnMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->getNullMock()->setAnnotation('INBOX/test', 'a', 'b');
     }
 
     public function testListAnnotationReturnsArray()
     {
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $this->getNullMock()->listAnnotation(
                 '/shared/vendor/kolab/folder-type'
             )
@@ -425,11 +427,13 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetIdReturnsString()
     {
-        $this->assertInternalType('string', $this->getNullMock()->getId());
+        $this->assertIsString($this->getNullMock()->getId());
     }
 
     public function testSelect()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getMessageMock();
         $mock->select('INBOX/Test');
     }
@@ -442,11 +446,10 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertEquals(1, $status['uidnext']);
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissing()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $mock = $this->getNullMock();
         $mock->select('INBOX/Test');
     }
@@ -461,6 +464,8 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testGetUids()
     {
+        $this->expectNotToPerformAssertions();
+
         $mock = $this->getMessageMock();
         $mock->getUids('INBOX/Test');
     }
@@ -514,8 +519,7 @@ extends Horde_Kolab_Storage_TestCase
 
     public function testBodypartResource()
     {
-        $this->assertInternalType(
-            'resource',
+        $this->assertIsResource(
             $this->getMessageMock()
             ->fetchBodypart(
                 'INBOX/Calendar', 4, '2'

--- a/test/Horde/Kolab/Storage/Unit/Driver/PearTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Driver/PearTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Driver_PearTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testGetNamespaceReturnsNamespaceHandler()
     {
@@ -74,7 +74,7 @@ extends PHPUnit_Framework_TestCase
 
     private function _getNamespaceMock()
     {
-        $imap = $this->getMock('Net_IMAP', array('hasCapability', 'getNameSpace'), array(), '', false, false);
+        $imap = $this->getMockBuilder('Net_IMAP')->setMethods(array('hasCapability', 'getNameSpace'))->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $imap->expects($this->once())
             ->method('hasCapability')
             ->with('NAMESPACE')

--- a/test/Horde/Kolab/Storage/Unit/FactoryTest.php
+++ b/test/Horde/Kolab/Storage/Unit/FactoryTest.php
@@ -30,29 +30,27 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testCreationFromParams()
     {
-        $factory = new Horde_Kolab_Storage_Factory(array('driver' => 'mock', 'logger' => $this->getMock('Horde_Log_Logger')));
+        $factory = new Horde_Kolab_Storage_Factory(array('driver' => 'mock', 'logger' => $this->getMockBuilder('Horde_Log_Logger')->getMock()));
         $this->assertInstanceOf(
             'Horde_Kolab_Storage',
             $factory->create()
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingDriver()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory(
             array()
         );
         $factory->createDriver();
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testInvalidDriver()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory(
             array('driver' => 'something')
         );
@@ -70,11 +68,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testInvalidNamespace()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory();
         $factory->createNamespace(
             'undefined', 'test'

--- a/test/Horde/Kolab/Storage/Unit/Folder/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/BaseTest.php
@@ -28,6 +28,8 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testConstructor()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_getFolderMock();
     }
 
@@ -45,11 +47,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingNamespace()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->getNamespace();
     }
 
@@ -61,11 +62,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingTitle()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->getTitle();
     }
 
@@ -90,11 +90,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingSubpath()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->getSubpath();
     }
 
@@ -105,11 +104,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->isDefault();
     }
 
@@ -121,11 +119,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingType()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->getType();
     }
 
@@ -137,11 +134,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testMissingPrefix()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->_getFolderMock()->getPrefix();
     }
 
@@ -155,7 +151,7 @@ extends Horde_Kolab_Storage_TestCase
 
     private function _getListMock($data = array())
     {
-        $query = $this->getMock('Horde_Kolab_Storage_List_Query_List');
+        $query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_List')->getMock();
         $query->expects($this->any())
             ->method('folderData')
             ->will($this->returnValue($data));
@@ -172,8 +168,8 @@ extends Horde_Kolab_Storage_TestCase
     {
         $this->markTestIncomplete('Currently broken');
         $GLOBALS['language'] = 'de_DE';
-        $storage = $this->getMock('Horde_Kolab_Storage', array(), array(), '', false, false);
-        $connection = $this->getMock('Horde_Kolab_Storage_Driver');
+        $storage = $this->getMockBuilder('Horde_Kolab_Storage')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $connection = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $connection->expects($this->once())
             ->method('getNamespace')
             ->will($this->returnValue(new Horde_Kolab_Storage_Driver_Namespace_Fixed()));
@@ -282,7 +278,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testTriggerOwn()
     {
         $this->markTestIncomplete('Currently broken');
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder', array('triggerUrl'));
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->setMethods(array('triggerUrl'))->getMock();
         $folder->expects($this->once())
             ->method('triggerUrl')
             ->with($this->equalTo('https://fb.example.org/freebusy/trigger/wrobel@example.org/Kalender.pfb'));
@@ -299,7 +295,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testTriggerForeign()
     {
         $this->markTestIncomplete('Currently broken');
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder', array('triggerUrl'));
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->setMethods(array('triggerUrl'))->getMock();
         $folder->expects($this->exactly(2))
             ->method('triggerUrl')
             ->with($this->equalTo('https://fb.example.org/freebusy/trigger/test@example.org/Kalender.pfb'));

--- a/test/Horde/Kolab/Storage/Unit/Folder/DataTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/DataTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Folder_DataTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testType()
     {
@@ -84,15 +84,15 @@ extends PHPUnit_Framework_TestCase
 
     private function _getData()
     {
-        $type = $this->getMock('Horde_Kolab_Storage_Folder_Type', array(), array('a'));
+        $type = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Type')->setConstructorArgs(array('a'))->getMock();
         $type->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('test'));
         $type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')

--- a/test/Horde/Kolab/Storage/Unit/Folder/NamespaceTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/NamespaceTest.php
@@ -27,11 +27,11 @@
 class Horde_Kolab_Storage_Unit_Folder_NamespaceTest
 extends Horde_Kolab_Storage_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
-        $this->_storage = $this->getMock('Horde_Kolab_Storage', array(), array(), '', false, false);
-        $this->_connection = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->_storage = $this->getMockBuilder('Horde_Kolab_Storage')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $this->_connection = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
     }
 
     public function testTitleForPersonalNS()

--- a/test/Horde/Kolab/Storage/Unit/Folder/Stamp/UidsTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/Stamp/UidsTest.php
@@ -82,7 +82,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testSerialize2()
     {
         $this->assertEquals(
-            'C:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":128:{a:2:{i:0;a:3:{s:11:"uidvalidity";s:2:"99";s:7:"uidnext";s:1:"5";s:5:"token";s:9:"somestamp";}i:1;a:3:{i:0;i:1;i:1;i:2;i:2;i:4;}}}',
+            'O:37:"Horde_Kolab_Storage_Folder_Stamp_Uids":2:{i:0;a:3:{s:11:"uidvalidity";s:2:"99";s:7:"uidnext";s:1:"5";s:5:"token";s:9:"somestamp";}i:1;a:3:{i:0;i:1;i:1;i:2;i:2;i:4;}}',
             serialize($this->_getStamp())
         );
     }

--- a/test/Horde/Kolab/Storage/Unit/Folder/Stamp/UidsTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/Stamp/UidsTest.php
@@ -28,7 +28,7 @@
 class Horde_Kolab_Storage_Unit_Folder_Stamp_UidsTest
 extends Horde_Kolab_Storage_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->status = array('uidvalidity' => '99', 'uidnext' => '5', 'token' => 'somestamp');
@@ -64,12 +64,11 @@ extends Horde_Kolab_Storage_TestCase
         $this->assertTrue($this->_getStamp()->isReset($stamp));
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testInvalidStampTypeForReset()
     {
-        $this->_getStamp()->isReset($this->getMock('Horde_Kolab_Storage_Folder_Stamp'));
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
+        $this->_getStamp()->isReset($this->getMockBuilder('Horde_Kolab_Storage_Folder_Stamp')->getMock());
     }
 
     public function testSerialize()
@@ -157,12 +156,11 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testInvalidStampType()
     {
-        $this->_getStamp()->getChanges($this->getMock('Horde_Kolab_Storage_Folder_Stamp'));
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
+        $this->_getStamp()->getChanges($this->getMockBuilder('Horde_Kolab_Storage_Folder_Stamp')->getMock());
     }
 
     public function testToString()

--- a/test/Horde/Kolab/Storage/Unit/Folder/TypeTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/TypeTest.php
@@ -26,10 +26,12 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Folder_TypeTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
+
         new Horde_Kolab_Storage_Folder_Type('event');
     }
 

--- a/test/Horde/Kolab/Storage/Unit/Folder/TypesTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Folder/TypesTest.php
@@ -26,10 +26,12 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Folder_TypesTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
+
         new Horde_Kolab_Storage_Folder_Types();
     }
 

--- a/test/Horde/Kolab/Storage/Unit/List/Manipulation/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Manipulation/BaseTest.php
@@ -26,11 +26,11 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Manipulation_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testCreateFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('create')
             ->with('TEST');
@@ -40,7 +40,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testCreateFolderWithType()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('create')
             ->with('TEST');
@@ -53,7 +53,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testDeleteFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('delete')
             ->with('TEST');
@@ -63,7 +63,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testRenameFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('rename')
             ->with('FOO', 'BAR');
@@ -73,9 +73,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterCreateFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Base($driver);
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Manipulation_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation_Listener')->getMock();
         $listener->expects($this->once())
             ->method('updateAfterCreateFolder')
             ->with('TEST');
@@ -85,9 +85,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterCreateFolderWithType()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Base($driver);
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Manipulation_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation_Listener')->getMock();
         $listener->expects($this->once())
             ->method('updateAfterCreateFolder')
             ->with('TEST', 'event');
@@ -97,9 +97,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterDeleteFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Base($driver);
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Manipulation_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation_Listener')->getMock();
         $listener->expects($this->once())
             ->method('updateAfterDeleteFolder')
             ->with('TEST');
@@ -109,9 +109,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterRenameFolder()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Base($driver);
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Manipulation_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation_Listener')->getMock();
         $listener->expects($this->once())
             ->method('updateAfterRenameFolder')
             ->with('FOO', 'BAR');

--- a/test/Horde/Kolab/Storage/Unit/List/Manipulation/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Manipulation/Decorator/LogTest.php
@@ -26,60 +26,60 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Manipulation_Decorator_LogTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testCreateFolder()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
         $base->expects($this->once())
             ->method('createFolder')
             ->with('TEST');
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $manipulation->createFolder('TEST');
     }
 
     public function testDeleteFolder()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
         $base->expects($this->once())
             ->method('deleteFolder')
             ->with('TEST');
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $manipulation->deleteFolder('TEST');
     }
 
     public function testRenameFolder()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
         $base->expects($this->once())
             ->method('renameFolder')
             ->with('FOO', 'BAR');
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $manipulation->renameFolder('FOO', 'BAR');
     }
 
     public function testRegisterListener()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
         $base->expects($this->once())
             ->method('registerListener');
         $manipulation = new Horde_Kolab_Storage_List_Manipulation_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Manipulation_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation_Listener')->getMock();
         $manipulation->registerListener($listener);
     }
 
     public function testCreateFolderLog()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(
@@ -96,8 +96,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testDeleteFolderLog()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(
@@ -114,8 +114,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testRenameFolderLog()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Manipulation');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Manipulation')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->exactly(2))
             ->method('debug')
             ->with(

--- a/test/Horde/Kolab/Storage/Unit/List/Query/Acl/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/Acl/BaseTest.php
@@ -24,7 +24,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_Acl_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testHasAclSupport()
     {
@@ -158,11 +158,10 @@ extends PHPUnit_Framework_TestCase
         $acl->setAcl('INBOX', 'user', 'lra');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testSetAclWithNoAclSupport()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $acl = $this->_getAcl(false);
         $acl->setAcl('INBOX', 'user', 'lra');
     }
@@ -176,18 +175,17 @@ extends PHPUnit_Framework_TestCase
         $acl->deleteAcl('INBOX', 'user');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testDeleteAclWithNoAclSupport()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $acl = $this->_getAcl(false);
         $acl->deleteAcl('INBOX', 'user');
     }
 
     private function _getAcl($has_support = true)
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $this->driver->expects($this->any())
             ->method('hasAclSupport')
             ->will($this->returnValue($has_support));

--- a/test/Horde/Kolab/Storage/Unit/List/Query/Acl/CacheTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/Acl/CacheTest.php
@@ -24,12 +24,12 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_Acl_CacheTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testInitGetAcl()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_Acl');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_Acl')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->cache->expects($this->exactly(3))
             ->method('hasQuery')
             ->with(
@@ -338,8 +338,8 @@ extends PHPUnit_Framework_TestCase
 
     private function _getAcl()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_Acl');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_Acl')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         return new Horde_Kolab_Storage_List_Query_Acl_Cache(
             $this->query, $this->cache
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/ActiveSync/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/ActiveSync/BaseTest.php
@@ -24,7 +24,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_Activesync_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testGetEmptyActiveSync()
     {
@@ -77,7 +77,7 @@ extends PHPUnit_Framework_TestCase
 
     private function _getActivesync()
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         return new Horde_Kolab_Storage_List_Query_ActiveSync_Base(
             $this->driver
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/ActiveSync/CacheTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/ActiveSync/CacheTest.php
@@ -24,12 +24,12 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_ActiveSync_CacheTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testInitActiveSync()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_ActiveSync');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_ActiveSync')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->cache->expects($this->once())
             ->method('hasQuery')
             ->with(Horde_Kolab_Storage_List_Query_ActiveSync_Cache::ACTIVE_SYNC)
@@ -168,8 +168,8 @@ extends PHPUnit_Framework_TestCase
 
     private function _getActivesync()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_ActiveSync');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_ActiveSync')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         return new Horde_Kolab_Storage_List_Query_ActiveSync_Cache(
             $this->query, $this->cache
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/List/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/List/BaseTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_List_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testListTypes()
     {
@@ -82,8 +82,8 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -155,8 +155,8 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -226,8 +226,8 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(false));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -277,11 +277,10 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testMissingFolderData()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $list = $this->_getList();
         $this->driver->expects($this->once())
             ->method('listFolders')
@@ -295,7 +294,7 @@ extends PHPUnit_Framework_TestCase
         $this->driver->expects($this->once())
             ->method('listFolders')
             ->will($this->returnValue(array('INBOX/Test')));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -326,8 +325,8 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $ns->expects($this->once())
             ->method('getType')
             ->will($this->returnValue(Horde_Kolab_Storage_Folder_Namespace::PERSONAL));
@@ -374,11 +373,10 @@ extends PHPUnit_Framework_TestCase
         $list->setDefault('INBOX/Foo');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testSetDefaultFailsWithoutPreviousType()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $list = $this->_getList();
 
         $this->driver->expects($this->once())
@@ -398,7 +396,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testSetDefaultResetPreviousDefault()
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $this->types = new Horde_Kolab_Storage_Folder_Types();
         $list = new Horde_Kolab_Storage_List_Query_List_Base(
             $this->driver,
@@ -432,8 +430,8 @@ extends PHPUnit_Framework_TestCase
                 )
             );
 
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $ns->expects($this->once())
             ->method('getType')
             ->will($this->returnValue(Horde_Kolab_Storage_Folder_Namespace::PERSONAL));
@@ -465,11 +463,11 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
         $ns->expects($this->once())
             ->method('getType')
             ->will($this->returnValue(Horde_Kolab_Storage_Folder_Namespace::PERSONAL));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('matchNamespace')
             ->with('INBOX/Test')
@@ -504,8 +502,8 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $ns->expects($this->once())
             ->method('getType')
             ->will($this->returnValue(Horde_Kolab_Storage_Folder_Namespace::PERSONAL));
@@ -539,11 +537,11 @@ extends PHPUnit_Framework_TestCase
         $this->mock_type->expects($this->once())
             ->method('isDefault')
             ->will($this->returnValue(true));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
         $ns->expects($this->once())
             ->method('getType')
             ->will($this->returnValue(Horde_Kolab_Storage_Folder_Namespace::PERSONAL));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->once())
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -563,9 +561,9 @@ extends PHPUnit_Framework_TestCase
 
     private function _getList()
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $this->types = $this->getMock('Horde_Kolab_Storage_Folder_Types');
-        $this->mock_type = $this->getMock('Horde_Kolab_Storage_Folder_Type', array(), array('event.default'));
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $this->types = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Types')->getMock();
+        $this->mock_type = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Type')->setConstructorArgs(array('event.default'))->getMock();
         return new Horde_Kolab_Storage_List_Query_List_Base(
             $this->driver,
             $this->types,

--- a/test/Horde/Kolab/Storage/Unit/List/Query/List/Cache/SynchronizationTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/List/Cache/SynchronizationTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_List_Cache_SynchronizationTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testSynchronizeNamespace()
     {
@@ -116,8 +116,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterCreateFolderExit()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(false));
@@ -135,8 +135,8 @@ extends PHPUnit_Framework_TestCase
     public function testUpdateAfterCreateFolder()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -167,8 +167,8 @@ extends PHPUnit_Framework_TestCase
     public function testUpdateAfterCreateFolderWithType()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -198,8 +198,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterDeleteFolderExit()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(false));
@@ -217,8 +217,8 @@ extends PHPUnit_Framework_TestCase
     public function testUpdateAfterDeleteFolder()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -248,8 +248,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testUpdateAfterRenameFolderExit()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(false));
@@ -267,8 +267,8 @@ extends PHPUnit_Framework_TestCase
     public function testUpdateAfterRenameFolder()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -298,8 +298,8 @@ extends PHPUnit_Framework_TestCase
 
     private function _getSynchronization()
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->driver->expects($this->once())
             ->method('listFolders')
             ->will($this->returnValue(array('INBOX/Test')));
@@ -307,8 +307,8 @@ extends PHPUnit_Framework_TestCase
             ->method('listAnnotation')
             ->with(Horde_Kolab_Storage_List_Query_List_Base::ANNOTATION_FOLDER_TYPE)
             ->will($this->returnValue(array('INBOX/Test' => 'a.default')));
-        $ns = $this->getMock('Horde_Kolab_Storage_Folder_Namespace_Element', array(), array('A', 'B', 'C'));
-        $namespace = $this->getMock('Horde_Kolab_Storage_Folder_Namespace', array(), array(array()));
+        $ns = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace_Element')->setConstructorArgs(array('A', 'B', 'C'))->getMock();
+        $namespace = $this->getMockBuilder('Horde_Kolab_Storage_Folder_Namespace')->setConstructorArgs(array(array()))->getMock();
         $namespace->expects($this->exactly(2))
             ->method('getOwner')
             ->with('INBOX/Test')
@@ -351,20 +351,20 @@ extends PHPUnit_Framework_TestCase
     public function testGetDuplicateDefaults()
     {
         $duplicates = array('a' => 'b');
-        $defaults = $this->getMock('Horde_Kolab_Storage_List_Query_List_Defaults_Bail');
+        $defaults = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_List_Defaults_Bail')->getMock();
         $defaults->expects($this->once())
             ->method('getDuplicates')
             ->will($this->returnValue($duplicates));
         $synchronization = new Horde_Kolab_Storage_List_Query_List_Cache_Synchronization(
-            $this->getMock('Horde_Kolab_Storage_Driver'), new Horde_Kolab_Storage_Folder_Types(), $defaults
+            $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock(), new Horde_Kolab_Storage_Folder_Types(), $defaults
         );
         $this->assertEquals($duplicates, $synchronization->getDuplicateDefaults());
     }
 
     public function testSetDefaultExit()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(false));
@@ -382,7 +382,7 @@ extends PHPUnit_Framework_TestCase
     public function testSetDefault()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('setAnnotation')
             ->with(
@@ -391,7 +391,7 @@ extends PHPUnit_Framework_TestCase
                 'contact.default'
             );
 
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -425,13 +425,12 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testSetDefaultFailsWithoutPreviousType()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array('hasNamespace', 'getFolderTypes'), array(), '', false, false);
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->setMethods(array('hasNamespace', 'getFolderTypes'))->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -453,13 +452,12 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testSetDefaultFailsOutsidePersonalNamespace()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array('hasNamespace', 'getFolderTypes'), array(), '', false, false);
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->setMethods(array('hasNamespace', 'getFolderTypes'))->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->once())
             ->method('hasNamespace')
             ->will($this->returnValue(true));
@@ -481,7 +479,7 @@ extends PHPUnit_Framework_TestCase
     public function testSetDefaultResetPreviousDefault()
     {
         $namespace = new Horde_Kolab_Storage_Folder_Namespace_Fixed('test');
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->exactly(2))
             ->method('setAnnotation')
             ->with(
@@ -496,7 +494,7 @@ extends PHPUnit_Framework_TestCase
                 )
             );
 
-        $cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $cache->expects($this->exactly(2))
             ->method('hasNamespace')
             ->will($this->returnValue(true));

--- a/test/Horde/Kolab/Storage/Unit/List/Query/List/CacheTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/List/CacheTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_List_CacheTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testListTypes()
     {
@@ -176,11 +176,10 @@ extends PHPUnit_Framework_TestCase
         $list->folderData('BAR');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testMissingFolderData()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $list = $this->_getList();
         $this->cache->expects($this->once())
             ->method('getQuery')
@@ -419,8 +418,8 @@ extends PHPUnit_Framework_TestCase
 
     private function _getList()
     {
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
-        $this->sync = $this->getMock('Horde_Kolab_Storage_List_Query_List_Cache_Synchronization', array(), array(), '', false, false);
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $this->sync = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_List_Cache_Synchronization')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         return new Horde_Kolab_Storage_List_Query_List_Cache(
             $this->sync, $this->cache
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/List/DefaultsTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/List/DefaultsTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_List_DefaultsTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testMarkCompleteIsComplete()
     {
@@ -72,11 +72,10 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testBailOnDoubleDefault()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $bail = new Horde_Kolab_Storage_List_Query_List_Defaults_Bail();
         $bail->rememberDefault('FooA', 'TypeFOO', 'Mr. Foo', false);
         $bail->rememberDefault('FooC', 'TypeFOO', 'Mr. Foo', false);
@@ -84,7 +83,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testLogOnDoubleDefault()
     {
-        $logger = $this->getMock('Horde_Log_Logger', array('err'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('err'))->getMock();
         $logger->expects($this->once())
             ->method('err')
             ->with('Both folders "FooA" and "FooC" of owner "Mr. Foo" are marked as default folder of type "TypeFOO"!');
@@ -97,7 +96,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testDuplicates()
     {
-        $logger = $this->getMock('Horde_Log_Logger', array('err'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('err'))->getMock();
         $log = new Horde_Kolab_Storage_List_Query_List_Defaults_Log(
             $logger
         );
@@ -115,7 +114,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testTriplicate()
     {
-        $logger = $this->getMock('Horde_Log_Logger', array('err'));
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('err'))->getMock();
         $log = new Horde_Kolab_Storage_List_Query_List_Defaults_Log(
             $logger
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/Share/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/Share/BaseTest.php
@@ -24,7 +24,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_Share_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testGetDescription()
     {
@@ -80,7 +80,7 @@ extends PHPUnit_Framework_TestCase
 
     private function _getShare()
     {
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         return new Horde_Kolab_Storage_List_Query_Share_Base(
             $this->driver
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Query/Share/CacheTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Query/Share/CacheTest.php
@@ -24,12 +24,12 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Query_Share_CacheTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testInitDescription()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_Share');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_Share')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->cache->expects($this->once())
             ->method('hasQuery')
             ->with(Horde_Kolab_Storage_List_Query_Share_Cache::DESCRIPTIONS)
@@ -91,8 +91,8 @@ extends PHPUnit_Framework_TestCase
 
     public function testInitParameter()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_Share');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_Share')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->cache->expects($this->once())
             ->method('hasLongTerm')
             ->with(Horde_Kolab_Storage_List_Query_Share_Cache::PARAMETERS)
@@ -294,8 +294,8 @@ extends PHPUnit_Framework_TestCase
 
     private function _getShare()
     {
-        $this->query = $this->getMock('Horde_Kolab_Storage_List_Query_Share');
-        $this->cache = $this->getMock('Horde_Kolab_Storage_List_Cache', array(), array(), '', false, false);
+        $this->query = $this->getMockBuilder('Horde_Kolab_Storage_List_Query_Share')->getMock();
+        $this->cache = $this->getMockBuilder('Horde_Kolab_Storage_List_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         return new Horde_Kolab_Storage_List_Query_Share_Cache(
             $this->query, $this->cache
         );

--- a/test/Horde/Kolab/Storage/Unit/List/Synchronization/BaseTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Synchronization/BaseTest.php
@@ -26,12 +26,12 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Synchronization_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testSynchronize()
     {
         $synchronization = new Horde_Kolab_Storage_List_Synchronization_Base();
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Synchronization_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization_Listener')->getMock();
         $listener->expects($this->once())
             ->method('synchronize');
         $synchronization->registerListener($listener);

--- a/test/Horde/Kolab/Storage/Unit/List/Synchronization/Decorator/LogTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/Synchronization/Decorator/LogTest.php
@@ -26,35 +26,35 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_Synchronization_Decorator_LogTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testRegisterListener()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Synchronization');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock();
         $base->expects($this->once())
             ->method('registerListener');
         $synchronization = new Horde_Kolab_Storage_List_Synchronization_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
-        $listener = $this->getMock('Horde_Kolab_Storage_List_Synchronization_Listener');
+        $listener = $this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization_Listener')->getMock();
         $synchronization->registerListener($listener);
     }
 
     public function testSynchronize()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Synchronization');
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock();
         $base->expects($this->once())
             ->method('synchronize');
         $synchronization = new Horde_Kolab_Storage_List_Synchronization_Decorator_Log(
-            $base, $this->getMock('Horde_Log_Logger')
+            $base, $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $synchronization->synchronize();
     }
 
     public function testSynchronizationLog()
     {
-        $base = $this->getMock('Horde_Kolab_Storage_List_Synchronization');
-        $logger = $this->getMock('Horde_Log_Logger', array('debug'));
+        $base = $this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock();
+        $logger = $this->getMockBuilder('Horde_Log_Logger')->setMethods(array('debug'))->getMock();
         $logger->expects($this->once())
             ->method('debug')
             ->with('Synchronized the Kolab folder list!');

--- a/test/Horde/Kolab/Storage/Unit/List/ToolsTest.php
+++ b/test/Horde/Kolab/Storage/Unit/List/ToolsTest.php
@@ -26,14 +26,14 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_List_ToolsTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testManipulation()
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array()
         );
         $this->assertInstanceOf(
@@ -46,8 +46,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'log' => array('debug')
             )
@@ -62,8 +62,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'log' => array('list_manipulation')
             )
@@ -78,8 +78,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array()
         );
         $this->assertInstanceOf(
@@ -92,8 +92,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'log' => array('debug')
             )
@@ -108,8 +108,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'log' => array('list_synchronization')
             )
@@ -120,29 +120,27 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testInvalidQuery()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array()
         );
         $tools->getQuery('TEST');
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_List_Exception
-     */
     public function testMissingQuery()
     {
+        $this->expectException('Horde_Kolab_Storage_List_Exception');
+
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array()
         );
         $tools->getQuery(Horde_Kolab_Storage_List_Tools::QUERY_SHARE);
@@ -152,8 +150,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array()
         );
         $tools->getQuery(Horde_Kolab_Storage_List_Tools::QUERY_BASE);
@@ -163,8 +161,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array('queries' => array(Horde_Kolab_Storage_List_Tools::QUERY_BASE))
         );
         $this->assertInstanceOf(
@@ -177,8 +175,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array('queries' => array(Horde_Kolab_Storage_List_Tools::QUERY_BASE))
         );
         $this->assertInstanceOf(
@@ -190,8 +188,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'queries' => array(
                     'list' => array(
@@ -213,8 +211,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'queries' => array(
                     'list' => array(
@@ -234,8 +232,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'queries' => array(
                     'list' => array(
@@ -256,8 +254,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'queries' => array(
                     'list' => array(
@@ -276,8 +274,8 @@ extends PHPUnit_Framework_TestCase
     {
         $tools = new Horde_Kolab_Storage_List_Tools(
             $this->_getDriver(),
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock(),
             array(
                 'queries' => array(
                     'list' => array(
@@ -302,8 +300,8 @@ extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('ID'));
         $tools = new Horde_Kolab_Storage_List_Tools(
             $driver,
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger')
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $this->assertEquals('ID', $tools->getId());
     }
@@ -316,15 +314,15 @@ extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('NAMESPACE'));
         $tools = new Horde_Kolab_Storage_List_Tools(
             $driver,
-            $this->getMock('Horde_Kolab_Storage_Cache', array(), array(), '', false, false),
-            $this->getMock('Horde_Log_Logger')
+            $this->getMockBuilder('Horde_Kolab_Storage_Cache')->disableOriginalConstructor()->disableOriginalClone()->getMock(),
+            $this->getMockBuilder('Horde_Log_Logger')->getMock()
         );
         $this->assertEquals('NAMESPACE', $tools->getNamespace());
     }
 
     private function _getDriver()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('getParameters')
             ->will(

--- a/test/Horde/Kolab/Storage/Unit/Object/MimeTypeTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Object/MimeTypeTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Object_MimeTypeTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider getObjectAndMimeTypes
@@ -39,11 +39,10 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Data_Exception
-     */
     public function testUndefinedMimeObjectType()
     {
+        $this->expectException('Horde_Kolab_Storage_Data_Exception');
+
         Horde_Kolab_Storage_Object_MimeType::getMimeTypeFromObjectType('UNDEFINED');
     }
 
@@ -156,11 +155,10 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Data_Exception
-     */
     public function testUndefinedMimeFolderType()
     {
+        $this->expectException('Horde_Kolab_Storage_Data_Exception');
+
         Horde_Kolab_Storage_Object_MimeType::getMimeTypesFromFolderType('UNDEFINED');
     }
 

--- a/test/Horde/Kolab/Storage/Unit/Object/Writer/FormatTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Object/Writer/FormatTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Object_Writer_FormatTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testLoad()
     {
@@ -34,12 +34,12 @@ extends PHPUnit_Framework_TestCase
         $data = "<?xml version=\"1.0\"?>\n<kolab><test/></kolab>";
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
-        $format = $this->getMock('Horde_Kolab_Format');
+        $format = $this->getMockBuilder('Horde_Kolab_Format')->getMock();
         $format->expects($this->once())
             ->method('load')
             ->with($content)
             ->will($this->returnValue($array));
-        $factory = $this->getMock('Horde_Kolab_Format_Factory');
+        $factory = $this->getMockBuilder('Horde_Kolab_Format_Factory')->getMock();
         $factory->expects($this->once())
             ->method('create')
             ->with('Xml', 'event', array())
@@ -47,7 +47,7 @@ extends PHPUnit_Framework_TestCase
         $raw = new Horde_Kolab_Storage_Object_Writer_Format(
             $factory
         );
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('setData')
             ->with($array);
@@ -62,12 +62,12 @@ extends PHPUnit_Framework_TestCase
         $data = "<?xml version=\"1.0\"?>\n<kolab><test/></kolab>";
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
-        $format = $this->getMock('Horde_Kolab_Format');
+        $format = $this->getMockBuilder('Horde_Kolab_Format')->getMock();
         $format->expects($this->once())
             ->method('load')
             ->with($content)
             ->will($this->throwException(new Horde_Kolab_Format_Exception()));
-        $factory = $this->getMock('Horde_Kolab_Format_Factory');
+        $factory = $this->getMockBuilder('Horde_Kolab_Format_Factory')->getMock();
         $factory->expects($this->once())
             ->method('create')
             ->with('Xml', 'event', array())
@@ -75,7 +75,7 @@ extends PHPUnit_Framework_TestCase
         $raw = new Horde_Kolab_Storage_Object_Writer_Format(
             $factory
         );
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('setContent')
             ->with($content);
@@ -92,12 +92,12 @@ extends PHPUnit_Framework_TestCase
         $data = "<?xml version=\"1.0\"?>\n<kolab><test/></kolab>";
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
-        $format = $this->getMock('Horde_Kolab_Format');
+        $format = $this->getMockBuilder('Horde_Kolab_Format')->getMock();
         $format->expects($this->once())
             ->method('save')
             ->with($array, array('previous' => 'previous'))
             ->will($this->returnValue($content));
-        $factory = $this->getMock('Horde_Kolab_Format_Factory');
+        $factory = $this->getMockBuilder('Horde_Kolab_Format_Factory')->getMock();
         $factory->expects($this->once())
             ->method('create')
             ->with('Xml', 'event', array())
@@ -105,7 +105,7 @@ extends PHPUnit_Framework_TestCase
         $raw = new Horde_Kolab_Storage_Object_Writer_Format(
             $factory
         );
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('getData')
             ->will($this->returnValue($array));
@@ -121,21 +121,20 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testSaveFailure()
     {
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
         $array = array('x' => 'y');
         $data = "<?xml version=\"1.0\"?>\n<kolab><test/></kolab>";
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
-        $format = $this->getMock('Horde_Kolab_Format');
+        $format = $this->getMockBuilder('Horde_Kolab_Format')->getMock();
         $format->expects($this->once())
             ->method('save')
             ->with($array, array('previous' => 'previous'))
             ->will($this->throwException(new Horde_Kolab_Format_Exception()));
-        $factory = $this->getMock('Horde_Kolab_Format_Factory');
+        $factory = $this->getMockBuilder('Horde_Kolab_Format_Factory')->getMock();
         $factory->expects($this->once())
             ->method('create')
             ->with('Xml', 'event', array())
@@ -143,7 +142,7 @@ extends PHPUnit_Framework_TestCase
         $raw = new Horde_Kolab_Storage_Object_Writer_Format(
             $factory
         );
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('getData')
             ->will($this->returnValue($array));

--- a/test/Horde/Kolab/Storage/Unit/Object/Writer/RawTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Object/Writer/RawTest.php
@@ -26,7 +26,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Object_Writer_RawTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testLoad()
     {
@@ -34,7 +34,7 @@ extends PHPUnit_Framework_TestCase
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
         $raw = new Horde_Kolab_Storage_Object_Writer_Raw();
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('setContent')
             ->with($content);
@@ -47,7 +47,7 @@ extends PHPUnit_Framework_TestCase
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data);
         $raw = new Horde_Kolab_Storage_Object_Writer_Raw();
-        $object = $this->getMock('Horde_Kolab_Storage_Object');
+        $object = $this->getMockBuilder('Horde_Kolab_Storage_Object')->getMock();
         $object->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($content));

--- a/test/Horde/Kolab/Storage/Unit/ObjectTest.php
+++ b/test/Horde/Kolab/Storage/Unit/ObjectTest.php
@@ -26,27 +26,26 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_ObjectTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $this->folder = $this->getMock('Horde_Kolab_Storage_Folder');
-        $this->driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
+        $this->driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Data_Exception
-     */
     public function testInvalidInitialStructure()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $this->expectException('Horde_Kolab_Storage_Data_Exception');
+
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $object->load('1', $this->folder, $data, new Horde_Mime_Part());
     }
 
     public function testObjectType()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $this->folder->expects($this->once())
             ->method('getType')
@@ -66,9 +65,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testObjectTypeDeviatesFromFolderType()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $headers->method('__call')
             ->with('getValue', array('X-Kolab-Type'))
             ->will($this->returnValue('application/x-vnd.kolab.note'));
@@ -94,9 +93,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testMissingKolabPart()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $headers->method('__call')
             ->with('getValue', array('X-Kolab-Type'))
             ->will($this->returnValue('application/x-vnd.kolab.note'));
@@ -121,18 +120,18 @@ extends PHPUnit_Framework_TestCase
             Horde_Kolab_Storage_Object::TYPE_INVALID,
             $object->getType()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Horde_Kolab_Storage_Object::ERROR_MISSING_KOLAB_PART,
-            array_keys($object->getParseErrors())
+            join(" ", array_keys($object->getParseErrors()))
         );
         $this->assertTrue($object->hasParseErrors());
     }
 
     public function testObjectRetainsHeadersIfLoaded()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $headers->method('__call')
             ->with('getValue', array('X-Kolab-Type'))
             ->will($this->returnValue('application/x-vnd.kolab.note'));
@@ -158,9 +157,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testObjectFetchesHeadersOnRequest()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $this->folder->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('event'));
@@ -187,9 +186,9 @@ extends PHPUnit_Framework_TestCase
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data_string);
 
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $this->folder->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('event'));
@@ -212,15 +211,14 @@ extends PHPUnit_Framework_TestCase
         $this->assertSame($content, $object->getContent());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testGetDriverThrowsExceptionIfUnset()
     {
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
         $object = new Horde_Kolab_Storage_Object();
         $object->create(
-            $this->getMock('Horde_Kolab_Storage_Folder'),
-            $this->getMock('Horde_Kolab_Storage_Object_Writer'),
+            $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock(),
+            $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock(),
             'event'
         );
     }
@@ -296,11 +294,10 @@ extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('a' => 'A'), $object->getData());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testUnserializeInvalidData()
     {
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
         $object = new Horde_Kolab_Storage_Object();
         $object->unserialize(serialize('A'));
     }        
@@ -318,9 +315,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testSerializeUnserializeRetainsErrors()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $headers->method('__call')
             ->with('getValue', array('X-Kolab-Type'))
             ->will($this->returnValue('application/x-vnd.kolab.note'));
@@ -343,17 +340,17 @@ extends PHPUnit_Framework_TestCase
         );
         $new_object = new Horde_Kolab_Storage_Object();
         $new_object->unserialize($object->serialize());
-        $this->assertContains(
+        $this->assertStringContainsString(
             Horde_Kolab_Storage_Object::ERROR_MISSING_KOLAB_PART,
-            array_keys($new_object->getParseErrors())
+            join(" ", array_keys($new_object->getParseErrors()))
         );
     }        
 
     public function testSerializeUnserializeRetainsType()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $this->folder->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('event'));
@@ -374,9 +371,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testSerializeUnserializeRetainsBackendIdAndFolder()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $this->folder->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('event'));
@@ -406,7 +403,7 @@ extends PHPUnit_Framework_TestCase
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data_string);
 
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $this->folder->expects($this->once())
             ->method('getType')
@@ -433,12 +430,11 @@ extends PHPUnit_Framework_TestCase
         $this->assertSame($content, $new_object->getContent());
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testFetchingContentsFailsWithMissingFolder()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $this->folder->expects($this->once())
             ->method('getType')
@@ -456,12 +452,11 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testFetchingContentsFailsWithMissingBackendId()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $this->folder->expects($this->once())
             ->method('getType')
@@ -479,13 +474,12 @@ extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testFetchingContentsFailsWithMissingMimeId()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $this->folder->expects($this->once())
             ->method('getType')
@@ -514,11 +508,11 @@ extends PHPUnit_Framework_TestCase
         $content = fopen('php://temp', 'r+');
         fwrite($content, $data_string);
 
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $data->expects($this->once())
             ->method('load');
-        $headers = $this->getMock('Horde_Mime_Headers');
+        $headers = $this->getMockBuilder('Horde_Mime_Headers')->getMock();
         $this->folder->expects($this->once())
             ->method('getType')
             ->will($this->returnValue('event'));
@@ -543,15 +537,15 @@ extends PHPUnit_Framework_TestCase
     public function testMimeEnvelope()
     {
         $driver = new Horde_Kolab_Storage_Stub_Driver('user');
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));
-        $writer = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $writer = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $object->setDriver($driver);
         $object->create($folder, $writer, 'event');
-        $this->assertContains('MIME-Version: 1.0', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('MIME-Version: 1.0', $driver->messages['INBOX'][0]);
     }
 
     public function testEnvelope()
@@ -559,30 +553,30 @@ extends PHPUnit_Framework_TestCase
         setlocale(LC_MESSAGES, 'C');
 
         $driver = new Horde_Kolab_Storage_Stub_Driver('user');
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));
-        $writer = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $writer = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $object->setData(array('uid' => 'UID'));
         $object->setDriver($driver);
         $object->create($folder, $writer, 'event');
 
-        $this->assertContains('Content-Disposition: attachment; filename="Kolab Groupware Data"', $driver->messages['INBOX'][0]);
-        $this->assertContains('Content-Type: multipart/mixed;', $driver->messages['INBOX'][0]);
-        $this->assertContains('Content-Type: text/plain; charset=utf-8; name="Kolab Groupware Information"', $driver->messages['INBOX'][0]);
-        $this->assertContains('Content-Disposition: inline; filename="Kolab Groupware Information"', $driver->messages['INBOX'][0]);
-        $this->assertContains(
+        $this->assertStringContainsString('Content-Disposition: attachment; filename="Kolab Groupware Data"', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('Content-Type: multipart/mixed;', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('Content-Type: text/plain; charset=utf-8; name="Kolab Groupware Information"', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('Content-Disposition: inline; filename="Kolab Groupware Information"', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString(
             "This is a Kolab Groupware object. To view this object you will need an email client that understands the Kolab Groupware format. For a list of such email clients please visit http://www.kolab.org/content/kolab-clients",
             $driver->messages['INBOX'][0]
         );
-        $this->assertContains('User-Agent: Horde_Kolab_Storage ' . Horde_Kolab_Storage::VERSION, $driver->messages['INBOX'][0]);
-        $this->assertContains('Subject: UID', $driver->messages['INBOX'][0]);
-        $this->assertContains('From: user', $driver->messages['INBOX'][0]);
-        $this->assertContains('To: user', $driver->messages['INBOX'][0]);
-        $this->assertContains('X-Kolab-Type: application/x-vnd.kolab.event', $driver->messages['INBOX'][0]);
-        $this->assertContains('Content-Type: application/x-vnd.kolab.event; name=kolab.xml', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('User-Agent: Horde_Kolab_Storage ' . Horde_Kolab_Storage::VERSION, $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('Subject: UID', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('From: user', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('To: user', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('X-Kolab-Type: application/x-vnd.kolab.event', $driver->messages['INBOX'][0]);
+        $this->assertStringContainsString('Content-Type: application/x-vnd.kolab.event; name=kolab.xml', $driver->messages['INBOX'][0]);
         $this->assertEquals(
             array(
                 0 => 'multipart/mixed',
@@ -595,18 +589,18 @@ extends PHPUnit_Framework_TestCase
 
     public function testSavedBackendId()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('appendMessage')
             ->will($this->returnValue(1001));
         $driver->expects($this->once())
             ->method('fetchHeaders')
             ->with('INBOX', 1001);
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));
-        $writer = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $writer = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $object->setData(array('uid' => 'UID'));
         $object->setDriver($driver);
@@ -614,20 +608,19 @@ extends PHPUnit_Framework_TestCase
         $object->getHeaders();
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testDriverException()
     {
-        $driver = $this->getMock('Horde_Kolab_Storage_Driver');
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
+        $driver = $this->getMockBuilder('Horde_Kolab_Storage_Driver')->getMock();
         $driver->expects($this->once())
             ->method('appendMessage')
             ->will($this->returnValue(false));
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));
-        $writer = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $writer = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $object = new Horde_Kolab_Storage_Object();
         $object->setData(array('uid' => 'UID'));
         $object->setDriver($driver);
@@ -637,7 +630,7 @@ extends PHPUnit_Framework_TestCase
     public function testGetUid()
     {
         $object = new Horde_Kolab_Storage_Object();
-        $this->assertInternalType('string', $object->getUid());
+        $this->assertIsString($object->getUid());
     }
 
     public function testNewUid()
@@ -657,7 +650,7 @@ extends PHPUnit_Framework_TestCase
 
     public function testSave()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $this->driver->expects($this->once())
             ->method('fetchComplete')
             ->will(
@@ -692,12 +685,11 @@ extends PHPUnit_Framework_TestCase
         $object->save($data);
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Object_Exception
-     */
     public function testSaveException()
     {
-        $data = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $this->expectException('Horde_Kolab_Storage_Object_Exception');
+
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $this->driver->expects($this->once())
             ->method('fetchComplete')
             ->will(
@@ -731,11 +723,11 @@ extends PHPUnit_Framework_TestCase
     public function testKolabPart()
     {
         $driver = new Horde_Kolab_Storage_Stub_Driver('user');
-        $folder = $this->getMock('Horde_Kolab_Storage_Folder');
+        $folder = $this->getMockBuilder('Horde_Kolab_Storage_Folder')->getMock();
         $folder->expects($this->once())
             ->method('getPath')
             ->will($this->returnValue('INBOX'));
-        $writer = $this->getMock('Horde_Kolab_Storage_Object_Writer');
+        $writer = $this->getMockBuilder('Horde_Kolab_Storage_Object_Writer')->getMock();
         $writer->expects($this->once())
             ->method('save')
             ->will($this->returnValue('<content/>'));

--- a/test/Horde/Kolab/Storage/Unit/QuerySet/UncachedTest.php
+++ b/test/Horde/Kolab/Storage/Unit/QuerySet/UncachedTest.php
@@ -67,11 +67,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testNoSuchDataQuerySet()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $factory = new Horde_Kolab_Storage_Factory();
         new Horde_Kolab_Storage_QuerySet_Uncached(
             $factory, array('data' => array('queryset' => 'NO_SUCH_SET'))

--- a/test/Horde/Kolab/Storage/Unit/Synchronization/OncePerSessionTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Synchronization/OncePerSessionTest.php
@@ -26,76 +26,71 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Synchronization_OncePerSessionTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testSynchronizeListReturn()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $this->assertNull($synchronization->synchronizeList($list));
     }
 
     public function testListSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
+        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['']);
     }
 
     public function testListSynchronizationInSession()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
     }
 
     public function testDuplicateListSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $synchronization->synchronizeList($list);
     }
 
     public function testSynchronizeDataReturn()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->assertNull($synchronization->synchronizeData($data));
     }
 
     public function testDataSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);
@@ -103,10 +98,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testDataSynchronizationInSession()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
@@ -116,10 +110,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testDuplicateDataSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_OncePerSession();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);

--- a/test/Horde/Kolab/Storage/Unit/Synchronization/TimeBasedTest.php
+++ b/test/Horde/Kolab/Storage/Unit/Synchronization/TimeBasedTest.php
@@ -26,76 +26,70 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Kolab_Storage_Unit_Synchronization_TimeBasedTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testSynchronizeListReturn()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $this->assertNull($synchronization->synchronizeList($list));
     }
 
     public function testListSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
     }
 
     public function testListSynchronizationInSession()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
     }
 
     public function testDuplicateListSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $synchronization->synchronizeList($list);
     }
 
     public function testSynchronizeDataReturn()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->assertNull($synchronization->synchronizeData($data));
     }
 
     public function testDataSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);
@@ -103,10 +97,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testDataSynchronizationInSession()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
@@ -116,10 +109,9 @@ extends PHPUnit_Framework_TestCase
 
     public function testDuplicateDataSynchronization()
     {
+        $_SESSION=array();
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);
@@ -128,11 +120,10 @@ extends PHPUnit_Framework_TestCase
 
     public function testDuplicateDataSynchronizationAfterSyncTimeElapsed()
     {
+        $_SESSION=array();
         $this->markTestSkipped('Test with embedded "sleep()". Only useful for the development phase.');
         $synchronization = new Horde_Kolab_Storage_Synchronization_TimeBased(1, 0);
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->exactly(2))
             ->method('synchronize');
         $synchronization->synchronizeData($data);

--- a/test/Horde/Kolab/Storage/Unit/SynchronizationTest.php
+++ b/test/Horde/Kolab/Storage/Unit/SynchronizationTest.php
@@ -31,39 +31,33 @@ extends Horde_Kolab_Storage_TestCase
     public function testSynchronizeListReturn()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $this->assertNull($synchronization->synchronizeList($list));
     }
 
     public function testListSynchronization()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
     }
 
     public function testListSynchronizationInSession()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
     }
@@ -71,12 +65,10 @@ extends Horde_Kolab_Storage_TestCase
     public function testDuplicateListSynchronization()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $list = $this->getMock(
-            'Horde_Kolab_Storage_List_Tools', array(), array(), '', false, false
-        );
+        $list = $this->getMockBuilder('Horde_Kolab_Storage_List_Tools')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $list->expects($this->once())
             ->method('getListSynchronization')
-            ->will($this->returnValue($this->getMock('Horde_Kolab_Storage_List_Synchronization')));
+            ->will($this->returnValue($this->getMockBuilder('Horde_Kolab_Storage_List_Synchronization')->getMock()));
         $synchronization->synchronizeList($list);
         $synchronization->synchronizeList($list);
     }
@@ -84,18 +76,14 @@ extends Horde_Kolab_Storage_TestCase
     public function testSynchronizeDataReturn()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->assertNull($synchronization->synchronizeData($data));
     }
 
     public function testDataSynchronization()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);
@@ -104,9 +92,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testDataSynchronizationInSession()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('getId')
             ->will($this->returnValue('test'));
@@ -117,9 +103,7 @@ extends Horde_Kolab_Storage_TestCase
     public function testDuplicateDataSynchronization()
     {
         $synchronization = new Horde_Kolab_Storage_Synchronization();
-        $data = $this->getMock(
-            'Horde_Kolab_Storage_Data_Base', array(), array(), '', false, false
-        );
+        $data = $this->getMockBuilder('Horde_Kolab_Storage_Data_Base')->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $data->expects($this->once())
             ->method('synchronize');
         $synchronization->synchronizeData($data);

--- a/test/Horde/Kolab/Storage/Unit/UncachedTest.php
+++ b/test/Horde/Kolab/Storage/Unit/UncachedTest.php
@@ -30,6 +30,8 @@ extends Horde_Kolab_Storage_TestCase
 {
     public function testConstruction()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->createStorage();
     }
 
@@ -88,11 +90,10 @@ extends Horde_Kolab_Storage_TestCase
         );
     }
 
-    /**
-     * @expectedException Horde_Kolab_Storage_Exception
-     */
     public function testNoSystemUser()
     {
+        $this->expectException('Horde_Kolab_Storage_Exception');
+
         $this->assertInstanceOf(
             'Horde_Kolab_Storage_List',
             $this->createStorage()->getSystemList('test')

--- a/test/Horde/Kolab/Storage/phpunit.xml
+++ b/test/Horde/Kolab/Storage/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-kolab-storage/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix some warnings due to php8.1 changes. https://salsa.debian.org/horde-team/php-horde-kolab-storage/-/blob/debian-sid/debian/patches/1020_php_8.1.patch
- Debian changes: Avoid log spam in PHP 8.1+ https://salsa.debian.org/horde-team/php-horde-kolab-storage/-/blob/debian-sid/debian/patches/2.patch
- Debian changes: Serialization format is changed. Fix tests. https://salsa.debian.org/horde-team/php-horde-kolab-storage/-/blob/debian-sid/debian/patches/fix_serialization_test.patch
