### PR TITLE
refactor(session): drop $_SESSION reads in favour of session shim API

### DIFF
--- a/lib/Horde/Kolab/Storage/Synchronization/OncePerSession.php
+++ b/lib/Horde/Kolab/Storage/Synchronization/OncePerSession.php
@@ -41,10 +41,12 @@ extends Horde_Kolab_Storage_Synchronization
      */
     public function synchronizeList(Horde_Kolab_Storage_List_Tools $list)
     {
+        $session = $GLOBALS['session'];
         $list_id = $list->getId();
-        if (empty($_SESSION['kolab_storage']['synchronization']['list'][$list_id])) {
+        $key = 'synchronization/list/' . $list_id;
+        if (empty($session->get('kolab_storage', $key))) {
             $list->getListSynchronization()->synchronize();
-            $_SESSION['kolab_storage']['synchronization']['list'][$list_id] = true;
+            $session->set('kolab_storage', $key, true);
         }
     }
 
@@ -56,10 +58,12 @@ extends Horde_Kolab_Storage_Synchronization
      */
     public function synchronizeData(Horde_Kolab_Storage_Data $data)
     {
+        $session = $GLOBALS['session'];
         $data_id = $data->getId();
-        if (empty($_SESSION['kolab_storage']['synchronization']['data'][$data_id])) {
+        $key = 'synchronization/data/' . $data_id;
+        if (empty($session->get('kolab_storage', $key))) {
             $data->synchronize();
-            $_SESSION['kolab_storage']['synchronization']['data'][$data_id] = true;
+            $session->set('kolab_storage', $key, true);
         }
     }
 }

--- a/lib/Horde/Kolab/Storage/Synchronization/TimeBased.php
+++ b/lib/Horde/Kolab/Storage/Synchronization/TimeBased.php
@@ -64,10 +64,12 @@ extends Horde_Kolab_Storage_Synchronization
      */
     public function synchronizeList(Horde_Kolab_Storage_List_Tools $list)
     {
+        $session = $GLOBALS['session'];
         $list_id = $list->getId();
-        if (empty($_SESSION['kolab_storage']['synchronization']['list'][$list_id])) {
+        $key = 'synchronization/list/' . $list_id;
+        if (empty($session->get('kolab_storage', $key))) {
             $list->getListSynchronization()->synchronize();
-            $_SESSION['kolab_storage']['synchronization']['list'][$list_id] = true;
+            $session->set('kolab_storage', $key, true);
         }
     }
 
@@ -83,7 +85,11 @@ extends Horde_Kolab_Storage_Synchronization
 
         if ($this->hasNotBeenSynchronizedYet($data_id) || $this->syncTimeHasElapsed($data_id)) {
             $data->synchronize();
-            $_SESSION['kolab_storage']['synchronization']['data'][$data_id] = time() + $this->_interval + rand(0, $this->_random_offset);
+            $GLOBALS['session']->set(
+                'kolab_storage',
+                'synchronization/data/' . $data_id,
+                time() + $this->_interval + rand(0, $this->_random_offset)
+            );
         }
     }
 
@@ -96,7 +102,9 @@ extends Horde_Kolab_Storage_Synchronization
      */
     private function hasNotBeenSynchronizedYet($data_id)
     {
-        return empty($_SESSION['kolab_storage']['synchronization']['data'][$data_id]);
+        return empty(
+            $GLOBALS['session']->get('kolab_storage', 'synchronization/data/' . $data_id)
+        );
     }
 
     /**
@@ -108,6 +116,6 @@ extends Horde_Kolab_Storage_Synchronization
      */
     private function syncTimeHasElapsed($data_id)
     {
-        return $_SESSION['kolab_storage']['synchronization']['data'][$data_id] < time();
+        return $GLOBALS['session']->get('kolab_storage', 'synchronization/data/' . $data_id) < time();
     }
 }

--- a/lib/Horde/Kolab/Storage/Synchronization/Token.php
+++ b/lib/Horde/Kolab/Storage/Synchronization/Token.php
@@ -51,10 +51,12 @@ extends Horde_Kolab_Storage_Synchronization
      */
     public function synchronizeList(Horde_Kolab_Storage_List_Tools $list)
     {
+        $session = $GLOBALS['session'];
         $list_id = $list->getId();
-        if (empty($_SESSION['kolab_storage']['synchronization']['list'][$list_id])) {
+        $key = 'synchronization/list/' . $list_id;
+        if (empty($session->get('kolab_storage', $key))) {
             $list->getListSynchronization()->synchronize();
-            $_SESSION['kolab_storage']['synchronization']['list'][$list_id] = true;
+            $session->set('kolab_storage', $key, true);
         }
     }
 

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -49,12 +49,13 @@ extends PhpUnitTestCase
 {
     public function setUp(): void
     {
-        $_SESSION = array();
+        require_once dirname(__DIR__) . '/test/TestSession.php';
+        $GLOBALS['session'] = new Horde_Kolab_Storage_Test_Session();
     }
 
     public function tearDown(): void
     {
-        $_SESSION = array();
+        unset($GLOBALS['session']);
     }
 
     protected function completeFactory($factory = null)

--- a/test/TestSession.php
+++ b/test/TestSession.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * In-memory stub session for unit tests.
+ *
+ * Satisfies just the Horde_Session subset the Kolab_Storage synchronization
+ * code calls (get / set / exists). Avoids the legacy shim's full bootstrap
+ * dependency on a Horde_Injector and SessionLifecycle.
+ *
+ * Usage in tests:
+ *   $GLOBALS['session'] = new Horde_Kolab_Storage_Test_Session();
+ *
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Kolab
+ * @package  Kolab_Storage
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+class Horde_Kolab_Storage_Test_Session
+{
+    /** @var array<string, array<string, mixed>> */
+    private $data = [];
+
+    public function get($app, $name, $mask = 0)
+    {
+        return $this->data[$app][$name] ?? null;
+    }
+
+    public function set($app, $name, $value, $mask = 0)
+    {
+        $this->data[$app][$name] = $value;
+    }
+
+    public function exists($app, $name)
+    {
+        return isset($this->data[$app][$name]);
+    }
+}

--- a/test/Unit/Synchronization/OncePerSessionTest.php
+++ b/test/Unit/Synchronization/OncePerSessionTest.php
@@ -64,7 +64,7 @@ extends TestCase
             ->method('getListSynchronization')
             ->will($this->returnValue($this->createMock(Horde_Kolab_Storage_List_Synchronization::class)));
         $synchronization->synchronizeList($list);
-        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
+        $this->assertTrue($GLOBALS['session']->get('kolab_storage', 'synchronization/list/test'));
     }
 
     public function testDuplicateListSynchronization()
@@ -105,7 +105,7 @@ extends TestCase
             ->method('getId')
             ->will($this->returnValue('test'));
         $synchronization->synchronizeData($data);
-        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['data']['test']);
+        $this->assertTrue($GLOBALS['session']->get('kolab_storage', 'synchronization/data/test'));
     }
 
     public function testDuplicateDataSynchronization()

--- a/test/Unit/Synchronization/TimeBasedTest.php
+++ b/test/Unit/Synchronization/TimeBasedTest.php
@@ -67,7 +67,7 @@ extends TestCase
             ->method('getListSynchronization')
             ->will($this->returnValue($this->createMock(Horde_Kolab_Storage_List_Synchronization::class)));
         $synchronization->synchronizeList($list);
-        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
+        $this->assertTrue($GLOBALS['session']->get('kolab_storage', 'synchronization/list/test'));
     }
 
     public function testDuplicateListSynchronization()
@@ -109,7 +109,7 @@ extends TestCase
             ->method('getId')
             ->will($this->returnValue('test'));
         $synchronization->synchronizeData($data);
-        $this->assertTrue(isset($_SESSION['kolab_storage']['synchronization']['data']['test']));
+        $this->assertTrue($GLOBALS['session']->exists('kolab_storage', 'synchronization/data/test'));
     }
 
     public function testDuplicateDataSynchronization()

--- a/test/Unit/SynchronizationTest.php
+++ b/test/Unit/SynchronizationTest.php
@@ -70,7 +70,7 @@ extends TestCase
             ->method('getListSynchronization')
             ->will($this->returnValue($this->createMock(Horde_Kolab_Storage_List_Synchronization::class)));
         $synchronization->synchronizeList($list);
-        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['list']['test']);
+        $this->assertTrue($GLOBALS['session']->get('kolab_storage', 'synchronization/list/test'));
     }
 
     public function testDuplicateListSynchronization()
@@ -113,7 +113,7 @@ extends TestCase
             ->method('getId')
             ->will($this->returnValue('test'));
         $synchronization->synchronizeData($data);
-        $this->assertTrue($_SESSION['kolab_storage']['synchronization']['data']['test']);
+        $this->assertTrue($GLOBALS['session']->get('kolab_storage', 'synchronization/data/test'));
     }
 
     public function testDuplicateDataSynchronization()


### PR DESCRIPTION
The three Synchronization strategies (TimeBased, OncePerSession,
Token) tracked per-session sync state via
$_SESSION['kolab_storage']['synchronization']['list'|'data'][$id].
Match how every other Horde app reads session state: via the
$GLOBALS['session'] shim. Slot key is flattened to
synchronization/list/<id> and synchronization/data/<id> under the
'kolab_storage' app scope, matching the auth_app/<app> pattern in
horde/Core's session.

Tests reset state via setUp/tearDown that previously cleared
$_SESSION; replace with a small named test stub
(Horde_Kolab_Storage_Test_Session) that holds an in-memory
[$app][$name] map and exposes the get/set/exists subset the
production code uses. Avoids pulling the heavyweight Horde_Session
shim into unit tests.

Test asserts use $GLOBALS['session']->get(...) and ->exists(...)
matching the new on-disk slot layout.

Removes the last $_SESSION reads in horde/Kolab_Storage. Unblocks
horde/Core's eventual retirement of the
Horde_Shutdown::addFinal() superglobal mirror.
